### PR TITLE
Add pinocchio to foxy and eloquent

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -74,3 +74,53 @@ tracks:
     vcs_type: git
     vcs_uri: https://github.com/stack-of-tasks/pinocchio.git
     version: :{auto}
+  foxy:
+    actions:
+    - bloom-export-upstream :{vcs_local_uri} :{vcs_type} --tag :{release_tag} --display-uri
+      :{vcs_uri} --name :{name} --output-dir :{archive_dir_path}
+    - git-bloom-import-upstream :{archive_path} :{patches} --release-version :{version}
+      --replace
+    - git-bloom-generate -y rosrelease :{ros_distro} --source upstream -i :{release_inc}
+    - git-bloom-generate -y rosdebian --prefix release/:{ros_distro} :{ros_distro}
+      -i :{release_inc} --os-name ubuntu
+    - git-bloom-generate -y rosdebian --prefix release/:{ros_distro} :{ros_distro}
+      -i :{release_inc} --os-name debian --os-not-required
+    - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
+      :{release_inc}
+    devel_branch: master
+    last_release: v2.4.5
+    last_version: 2.4.5
+    name: upstream
+    patches: null
+    release_inc: '1'
+    release_repo_url: git@github.com:ipab-slmc/pinocchio_catkin-release.git
+    release_tag: v:{version}
+    ros_distro: foxy
+    vcs_type: git
+    vcs_uri: https://github.com/stack-of-tasks/pinocchio.git
+    version: :{auto}
+  eloquent:
+    actions:
+    - bloom-export-upstream :{vcs_local_uri} :{vcs_type} --tag :{release_tag} --display-uri
+      :{vcs_uri} --name :{name} --output-dir :{archive_dir_path}
+    - git-bloom-import-upstream :{archive_path} :{patches} --release-version :{version}
+      --replace
+    - git-bloom-generate -y rosrelease :{ros_distro} --source upstream -i :{release_inc}
+    - git-bloom-generate -y rosdebian --prefix release/:{ros_distro} :{ros_distro}
+      -i :{release_inc} --os-name ubuntu
+    - git-bloom-generate -y rosdebian --prefix release/:{ros_distro} :{ros_distro}
+      -i :{release_inc} --os-name debian --os-not-required
+    - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
+      :{release_inc}
+    devel_branch: master
+    last_release: v2.4.5
+    last_version: 2.4.5
+    name: upstream
+    patches: null
+    release_inc: '1'
+    release_repo_url: git@github.com:ipab-slmc/pinocchio_catkin-release.git
+    release_tag: v:{version}
+    ros_distro: eloquent
+    vcs_type: git
+    vcs_uri: https://github.com/stack-of-tasks/pinocchio.git
+    version: :{auto}


### PR DESCRIPTION
Hello,

I am actually on an internship at LAAS-CNRS / AIP-Primeca to release packages of the Stack of Stacks on melodic, noetic, foxy and eloquent:  http://stack-of-tasks.github.io/development.html
I already released dynamic-graph and dynamic-graph-python: https://index.ros.org/p/dynamic-graph/github-stack-of-tasks-dynamic-graph/
Some packages are dependent on Pinocchio to be released on foxy and eloquent. Is it possible to release Pinocchio on those two rosdistros?

Best regards,

Thomas PEYRUCAIN